### PR TITLE
417. Pacific Atlantic Water Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ LeetCode の問題を以下手順で解く
 
 ## 解いた問題一覧
 
-| #   | Title                                                                 | Language | Difficulty |
-| --- | --------------------------------------------------------------------- | -------- | ---------- |
-| 322 | [Coin Change](https://leetcode.com/problems/coin-change/description/) | Python3  | Medium     |
+| #   | Title                                                                                                 | Language | Difficulty |
+| --- | ----------------------------------------------------------------------------------------------------- | -------- | ---------- |
+| 322 | [Coin Change](https://leetcode.com/problems/coin-change/description/)                                 | Python3  | Medium     |
+| 417 | [Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow/description/) | Python3  | Medium     |
 
 ## その他
 

--- a/problems/medium/python3/417/417.pacific-atlantic-water-flow.step1.py
+++ b/problems/medium/python3/417/417.pacific-atlantic-water-flow.step1.py
@@ -1,0 +1,72 @@
+#
+# @lc app=leetcode id=417 lang=python3
+#
+# [417] Pacific Atlantic Water Flow
+#
+
+# @lc code=start
+class Solution:
+    def pacificAtlantic(self, heights: List[List[int]]) -> List[List[int]]:
+        m, n = len(heights), len(heights[0])
+        canFlowToPacificOcean = [[False for _ in range(n)] for _ in range(m)]
+        canFlowToAtlanticOcean = [[False for _ in range(n)] for _ in range(m)]
+
+        self._canFlowBackFromPacificOcean(heights, canFlowToPacificOcean)
+        self._canFlowBackFromAtlanticOcean(heights, canFlowToAtlanticOcean)
+
+        canFlowToBothOcean = []
+        for row in range(m):
+            for col in range(n):
+                if canFlowToPacificOcean[row][col] and canFlowToAtlanticOcean[row][col]:
+                    canFlowToBothOcean.append([row, col])
+        return canFlowToBothOcean
+
+    def _canFlowBackFromPacificOcean(self, heights: List[List[int]], canFlowToPacificOcean: List[List[int]]):
+        m, n = len(heights), len(heights[0])
+        visited = [[False for _ in range(n)] for _ in range(m)]
+        canFlowCells = []
+        for row in range(m):
+            canFlowCells.append((row, 0))
+        for col in range(n):
+            canFlowCells.append((0, col))
+
+        while canFlowCells:
+            row, col = canFlowCells.pop()
+            if visited[row][col]:
+                continue
+            visited[row][col] = True
+            canFlowToPacificOcean[row][col] = True
+
+            for _row, _col in [(row + 1, col), (row - 1, col), (row, col + 1), (row, col - 1)]:
+                if _row < 0 or m <= _row or _col < 0 or n <= _col:
+                    continue
+                if visited[_row][_col]:
+                    continue
+                if heights[_row][_col] >= heights[row][col]:
+                    canFlowCells.append((_row, _col))
+
+    def _canFlowBackFromAtlanticOcean(self, heights: List[List[int]], canFlowToAtlanticOcean: List[List[int]]):
+        m, n = len(heights), len(heights[0])
+        visited = [[False for _ in range(n)] for _ in range(m)]
+        canFlowCells = []
+        for row in range(m):
+            canFlowCells.append((row, n-1))
+        for col in range(n):
+            canFlowCells.append((m-1, col))
+
+        while canFlowCells:
+            row, col = canFlowCells.pop()
+            if visited[row][col]:
+                continue
+            visited[row][col] = True
+            canFlowToAtlanticOcean[row][col] = True
+
+            for _row, _col in [(row + 1, col), (row - 1, col), (row, col + 1), (row, col - 1)]:
+                if _row < 0 or m <= _row or _col < 0 or n <= _col:
+                    continue
+                if visited[_row][_col]:
+                    continue
+                if heights[_row][_col] >= heights[row][col]:
+                    canFlowCells.append((_row, _col))
+
+# @lc code=end

--- a/problems/medium/python3/417/417.pacific-atlantic-water-flow.step2.py
+++ b/problems/medium/python3/417/417.pacific-atlantic-water-flow.step2.py
@@ -1,0 +1,38 @@
+#
+# @lc app=leetcode id=417 lang=python3
+#
+# [417] Pacific Atlantic Water Flow
+#
+
+# @lc code=start
+class Solution:
+    def pacificAtlantic(self, heights: List[List[int]]) -> List[List[int]]:
+        m, n = len(heights), len(heights[0])
+        can_flow_to_pacific = [[False for _ in range(n)] for _ in range(m)]
+        can_flow_to_atlantic = [[False for _ in range(n)] for _ in range(m)]
+
+        for row in range(m):
+            self._can_flow_back_from_ocean(heights, can_flow_to_pacific, row, 0)
+            self._can_flow_back_from_ocean(heights, can_flow_to_atlantic, row, n-1)
+        for col in range(n):
+            self._can_flow_back_from_ocean(heights, can_flow_to_pacific, 0, col)
+            self._can_flow_back_from_ocean(heights, can_flow_to_atlantic, m-1, col)
+
+        can_flow_to_both = []
+        for row in range(m):
+            for col in range(n):
+                if can_flow_to_pacific[row][col] and can_flow_to_atlantic[row][col]:
+                    can_flow_to_both.append([row, col])
+        return can_flow_to_both
+
+    def _can_flow_back_from_ocean(self, heights: List[List[int]], can_flow_to_ocean: List[List[int]], row: int, col: int):
+        can_flow_to_ocean[row][col] = True
+        m, n = len(heights), len(heights[0])
+        for _row, _col in [(row + 1, col), (row - 1, col), (row, col + 1), (row, col - 1)]:
+            if _row < 0 or m <= _row or _col < 0 or n <= _col:
+                continue
+            if can_flow_to_ocean[_row][_col]:
+                continue
+            if heights[_row][_col] >= heights[row][col]:
+                self._can_flow_back_from_ocean(heights, can_flow_to_ocean, _row, _col)
+# @lc code=end

--- a/problems/medium/python3/417/417.pacific-atlantic-water-flow.step3.py
+++ b/problems/medium/python3/417/417.pacific-atlantic-water-flow.step3.py
@@ -1,0 +1,38 @@
+#
+# @lc app=leetcode id=417 lang=python3
+#
+# [417] Pacific Atlantic Water Flow
+#
+
+# @lc code=start
+class Solution:
+    def pacificAtlantic(self, heights: List[List[int]]) -> List[List[int]]:
+        m, n = len(heights), len(heights[0])
+        can_flow_to_pacific = [[False for _ in range(n)] for _ in range(m)]
+        can_flow_to_atlantic = [[False for _ in range(n)] for _ in range(m)]
+
+        for row in range(m):
+            self._can_flow_back_from_ocean(heights, can_flow_to_pacific, row, 0)
+            self._can_flow_back_from_ocean(heights, can_flow_to_atlantic, row, n-1)
+        for col in range(n):
+            self._can_flow_back_from_ocean(heights, can_flow_to_pacific, 0, col)
+            self._can_flow_back_from_ocean(heights, can_flow_to_atlantic, m-1, col)
+
+        can_flow_to_both = []
+        for row in range(m):
+            for col in range(n):
+                if can_flow_to_pacific[row][col] and can_flow_to_atlantic[row][col]:
+                    can_flow_to_both.append([row, col])
+        return can_flow_to_both
+
+    def _can_flow_back_from_ocean(self, heights: List[List[int]], can_flow: List[List[bool]], row: int, col: int):
+        can_flow[row][col] = True
+        m, n = len(heights), len(heights[0])
+        for r, c in [(row + 1, col), (row - 1, col), (row, col + 1), (row, col - 1)]:
+            if r < 0 or m <= r or c < 0 or n <= c:
+                continue
+            if can_flow[r][c]:
+                continue
+            if heights[r][c] >= heights[row][col]:
+                self._can_flow_back_from_ocean(heights, can_flow, r, c)
+# @lc code=end


### PR DESCRIPTION
### Problem

- https://leetcode.com/problems/pacific-atlantic-water-flow/description/

### Description

- Step1
    - DFS で解くことを思いつく
        - Pacific と Atlantic それぞれの臨海部から上る方向に調べていき、Pacific に到達できるセルと Atlantic に到達できるセルの2次元配列を作成
        - 両方とも True なものを調べて出力
    - うまく処理を共通化させたかったがぱっとは思いつかず、ほぼ同じ関数を2つ作って対応
- Step2
    - 過去の自分の提出（おそらく Solutions のなにかを参考にした解法）を見て修正
        - `_canFlowBackFromXxxOcean()` から visited を削除（`canFlowToXxxOcean` のみで対応可）
        - `_canFlowBackFromXxxOcean()` 内でまとめて臨海部を受け取るのではなく、起点ごとに呼び出す
        - DFS から再帰に変更（ぱっと見がスッキリするので再帰を選んだが可読性は DFS より良くないかもしれない）
    - camelCase に引っ張られていたが、Python なので snake_case に変更
- Step3
    - 繰り返し書いている中で以下に違和感を覚えたので修正
        - ローカル関数の中で `_row`, `_col` を使っていたが、同じ場所で使っていた `row`, `col` と見分けづらいので `r`, `c` のように省略形にした（for ループのスコープがせまかったことも理由の1つ）
        - ローカル関数の引数である `can_flow_to_ocean: List[List[int]]` の型が誤っていたので修正（正しくは `List[List[bool]]`）
    - 違和感を覚えたが結局修正しなかったもの
        - 値が変わらない  `heights` をローカル関数に何度も渡すのが冗長に感じた（`self.heights = heights` のようにインスタンス変数として、ローカル関数の引数にはしないほうがスマートかもしれない）
        - 答えは `List[List[int]]` という型になるので `can_flow_to_both` という変数名はイマイチだったかもしれない（`can_flow_to_xxx` を `List[List[bool]]` という型で使っていたこともあり、同じ型のものであると誤解を招きそう）
        - `(0, 0)` と `(m-1, n-1)` のセルに関しては2回起点となるが、重複しないように変にずらすほうが可読性が落ちると思ったのでそのままとした

### Note

- 同じ問題を1年2ヶ月前に解いた経験あり
    - その際には全マスを起点に両方にたどりつくかを調べていこうとしたが、非常に複雑になってしまった
    - そのため臨海部を起点にするとわかりやすいという方針はぼんやりと覚えていた