### PR TITLE
5. Longest Palindromic Substring

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ LeetCode の問題を以下手順で解く
 
 ## 解いた問題一覧
 
-| #   | Title                                                                                                 | Language | Difficulty |
-| --- | ----------------------------------------------------------------------------------------------------- | -------- | ---------- |
-| 143 | [Reorder List](https://leetcode.com/problems/reorder-list/description/)                               | Python3  | Medium     |
-| 207 | [Course Schedule](https://leetcode.com/problems/ourse-schedule/description/)                          | Python3  | Medium     |
-| 322 | [Coin Change](https://leetcode.com/problems/coin-change/description/)                                 | Python3  | Medium     |
-| 417 | [Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow/description/) | Python3  | Medium     |
+| #   | Title                                                                                                     | Language | Difficulty |
+| --- | --------------------------------------------------------------------------------------------------------- | -------- | ---------- |
+| 5   | [Longest Palindromic Substring](https://leetcode.com/problems/longest-palindromic-substring/description/) | Python3  | Medium     |
+| 143 | [Reorder List](https://leetcode.com/problems/reorder-list/description/)                                   | Python3  | Medium     |
+| 207 | [Course Schedule](https://leetcode.com/problems/ourse-schedule/description/)                              | Python3  | Medium     |
+| 322 | [Coin Change](https://leetcode.com/problems/coin-change/description/)                                     | Python3  | Medium     |
+| 417 | [Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow/description/)     | Python3  | Medium     |
 
 ## その他
 

--- a/problems/medium/python3/5/longest-palindromic-substring.step1.py
+++ b/problems/medium/python3/5/longest-palindromic-substring.step1.py
@@ -1,0 +1,32 @@
+#
+# @lc app=leetcode id=5 lang=python3
+#
+# [5] Longest Palindromic Substring
+#
+
+# @lc code=start
+class Solution:
+    def longestPalindrome(self, s: str) -> str:
+        n = len(s)
+        longest_length, longest_palindrome = self.get_palindrome(s, 0, 0)
+        for i in range(1, n):
+            _length1, _palindrome1 = self.get_palindrome(s, i-1, i)
+            _length2, _palindrome2 = self.get_palindrome(s, i, i)
+            if _length1 > longest_length:
+                longest_length = _length1
+                longest_palindrome = _palindrome1
+            if _length2 > longest_length:
+                longest_length = _length2
+                longest_palindrome = _palindrome2
+        return longest_palindrome
+
+    def get_palindrome(self, s: str, left_center: int, right_center: int) -> (int, str):
+        n = len(s)
+        while s[left_center] == s[right_center]:
+            left_center -= 1
+            right_center += 1
+            if not (0 <= left_center and right_center < n):
+                break
+        length = right_center - left_center - 1
+        return length, s[left_center+1:right_center]
+# @lc code=end

--- a/problems/medium/python3/5/longest-palindromic-substring.step2.py
+++ b/problems/medium/python3/5/longest-palindromic-substring.step2.py
@@ -1,0 +1,29 @@
+#
+# @lc app=leetcode id=5 lang=python3
+#
+# [5] Longest Palindromic Substring
+#
+
+# @lc code=start
+class Solution:
+    def longestPalindrome(self, s: str) -> str:
+        n = len(s)
+        longest_palindrome = s[0]
+        for i in range(1, n):
+            even_palindrome = self.get_palindrome(s, i - 1, i)
+            odd_palindrome = self.get_palindrome(s, i, i)
+            if len(even_palindrome) > len(longest_palindrome):
+                longest_palindrome = even_palindrome
+            if len(odd_palindrome) > len(longest_palindrome):
+                longest_palindrome = odd_palindrome
+        return longest_palindrome
+
+    def get_palindrome(self, s: str, left: int, right: int) -> str:
+        n = len(s)
+        while 0 <= left and right < n:
+            if s[left] != s[right]:
+                break
+            left -= 1
+            right += 1
+        return s[left + 1:right]
+# @lc code=end

--- a/problems/medium/python3/5/longest-palindromic-substring.step3.py
+++ b/problems/medium/python3/5/longest-palindromic-substring.step3.py
@@ -1,0 +1,29 @@
+#
+# @lc app=leetcode id=5 lang=python3
+#
+# [5] Longest Palindromic Substring
+#
+
+# @lc code=start
+class Solution:
+    def longestPalindrome(self, s: str) -> str:
+        n = len(s)
+        longest = s[0]
+        for i in range(1, n):
+            even = self.get_palindrome(s, i - 1, i)
+            odd = self.get_palindrome(s, i, i)
+            if len(even) > len(longest):
+                longest = even
+            if len(odd) > len(longest):
+                longest = odd
+        return longest
+
+    def get_palindrome(self, s: str, left: int, right: int) -> str:
+        n = len(s)
+        while 0 <= left and right < n:
+            if s[left] != s[right]:
+                break
+            left -= 1
+            right += 1
+        return s[left + 1:right]
+# @lc code=end

--- a/problems/medium/python3/5/longest-palindromic-substring.step3.py
+++ b/problems/medium/python3/5/longest-palindromic-substring.step3.py
@@ -9,20 +9,16 @@ class Solution:
     def longestPalindrome(self, s: str) -> str:
         n = len(s)
         longest = s[0]
-        for i in range(1, n):
-            even = self.get_palindrome(s, i - 1, i)
-            odd = self.get_palindrome(s, i, i)
-            if len(even) > len(longest):
-                longest = even
-            if len(odd) > len(longest):
-                longest = odd
+        for offset in range(2):
+            for i in range(n):
+                palindrome = self.get_palindrome(s, i, i + offset)
+                if len(palindrome) > len(longest):
+                    longest = palindrome
         return longest
 
     def get_palindrome(self, s: str, left: int, right: int) -> str:
         n = len(s)
-        while 0 <= left and right < n:
-            if s[left] != s[right]:
-                break
+        while 0 <= left and right < n and s[left] == s[right]:
             left -= 1
             right += 1
         return s[left + 1:right]


### PR DESCRIPTION
### Problem

- https://leetcode.com/problems/longest-palindromic-substring/description/

### Description

- Step1
    - 20分で Pass
    - 時間計算量：`O(N^2)`、空間計算量：`O(1)`
    - 中心となる index を与えると、そこを中心として得られる最長の回文を返す関数を作成
        - 回文の長さが奇数・偶数のケースがあるので中心は引数として2つ受け入れる
        - 奇数長・偶数長のどちらでも同じ関数でいい感じに実装したかったが、偶数のケースではじめから回文でないときには返り値が適切でない実装となっている（気がする）
            - `"ab"` のようなとき、`get_palindrome(s, 0, 1)` とすると返り値は `0, ""` となってしまう
            - ↑ は問題を解く上では影響がないが、関数単体で見たときに直感と異なる（関数名からの直感は `1, "a"` または `1, "b"` が返ってきてほしいと読む人は感じるかもしれない）
            - ここをうまくやろうとして時間がかかった（最終的に諦めて提出）
            - 文字列だけでなく長さも返したほうが `longest_palindrome` 更新時に良いかと思ったがそうでもなかった
    - 初期値を `(left_center, right_center) = (0, 0)` で定義し、あとは `(left_center, right_center) = (i-1, i), (i, i)` のケースでループを回して最長のものを求める
        - よくよく考えれば初期値は必ず `1, s[0]` となるのでわざわざ関数を呼ばなくてよさそう
        - `_palindrome1`, `_palindrome2` のあたりももっとスマートにできないか考えたがとくに思いつかず
- Step2
    - 命名関連の修正
        - `_palindrome1`, `_palindrome2` を `even_palindrome`, `odd_palindrome` へ変更
            - この変数名にすることで上で書いた関数から `""` のような値が返ってきても違和感が減るかもしれない（とはいえ、関数単体では問題解決していない）
        - `get_palindrome()` の引数を `left_center`, `right_center` から `left`, `right` へ変更
            - 引数単体と関数内での使われ方が違っていた（受け取ったタイミングは始点だが、以降はポインタとして使われる）
            - `xxx_center` がポインタとして使われていることの違和感のほうが大きいと感じたため `_center` 部分を削除
    - その他の修正
        - while 文を微修正
            - while 文中の最後に break の判断があるコードに違和感を持ったため、early break 形式に変更
            - 日本語に訳したときに「`left`, `right` がともに範囲内なら続ける -> `s[left]` と `s[right]` が異なる場合は終了」とするのがシンプルに思えたので if 文も位置を逆にした
        - `longest_palindrome` の初期値はシンプルに `s[0]` を使用
        - とくに便利でなかったので関数の返り値として `length` を返す部分は削除
        - 演算子の前後にスペースを追加（スライスはスペースなしでよさそう、https://peps.python.org/pep-0008/ ）
- Step3
    - Step2 からとくに変更はないが、`longest_palindrome`, `even_palindrome`, `odd_palindrome` と毎回 `_palindrome` を書くのが冗長に感じたので途中から `_palindrome` は省略した

### Note

- 同じ問題を1年1ヶ月前に解いた経験あり
