### PR TITLE
73. Set Matrix Zeroes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ LeetCode の問題を以下手順で解く
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- |
 | 3   | [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/description/) | Python3  | Medium     |
 | 5   | [Longest Palindromic Substring](https://leetcode.com/problems/longest-palindromic-substring/description/)                                   | Python3  | Medium     |
+| 73  | [Set Matrix Zeroes](https://leetcode.com/problems/set-matrix-zeroes/description/)                                                           | Python3  | Medium     |
 | 143 | [Reorder List](https://leetcode.com/problems/reorder-list/description/)                                                                     | Python3  | Medium     |
 | 153 | [Find Minimum in Rotated Sorted Array](https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/description/)                     | Python3  | Medium     |
 | 207 | [Course Schedule](https://leetcode.com/problems/ourse-schedule/description/)                                                                | Python3  | Medium     |

--- a/problems/medium/python3/73/set-matrix-zeroes.step1.py
+++ b/problems/medium/python3/73/set-matrix-zeroes.step1.py
@@ -1,0 +1,37 @@
+#
+# @lc app=leetcode id=73 lang=python3
+#
+# [73] Set Matrix Zeroes
+#
+
+# @lc code=start
+class Solution:
+    def setZeroes(self, matrix: List[List[int]]) -> None:
+        """
+        Do not return anything, modify matrix in-place instead.
+        """
+        m = len(matrix)
+        n = len(matrix[0])
+        first_row_is_zero = any([matrix[0][col] == 0 for col in range(n)])
+        first_col_is_zero = any([matrix[row][0] == 0 for row in range(m)])
+
+        for row in range(1, m):
+            for col in range(1, n):
+                if matrix[row][col] == 0:
+                    matrix[row][0] = 0
+                    matrix[0][col] = 0
+
+        for row in range(1, m):
+            if matrix[row][0] == 0:
+                matrix[row] = [0 for _ in range(n)]
+        for col in range(1, n):
+            if matrix[0][col] == 0:
+                for row in range(m):
+                    matrix[row][col] = 0
+
+        if first_row_is_zero:
+            matrix[0] = [0 for _ in range(n)]
+        if first_col_is_zero:
+            for row in range(m):
+                matrix[row][0] = 0
+# @lc code=end

--- a/problems/medium/python3/73/set-matrix-zeroes.step2.py
+++ b/problems/medium/python3/73/set-matrix-zeroes.step2.py
@@ -1,0 +1,35 @@
+#
+# @lc app=leetcode id=73 lang=python3
+#
+# [73] Set Matrix Zeroes
+#
+
+# @lc code=start
+class Solution:
+    def setZeroes(self, matrix: List[List[int]]) -> None:
+        """
+        Do not return anything, modify matrix in-place instead.
+        """
+        m = len(matrix)
+        n = len(matrix[0])
+        first_row_has_zero = any([matrix[0][col] == 0 for col in range(n)])
+        first_col_has_zero = any([matrix[row][0] == 0 for row in range(m)])
+
+        for row in range(1, m):
+            for col in range(1, n):
+                if matrix[row][col] == 0:
+                    matrix[row][0] = 0
+                    matrix[0][col] = 0
+
+        for row in range(1, m):
+            for col in range(1, n):
+                if matrix[row][0] == 0 or matrix[0][col] == 0:
+                    matrix[row][col] = 0
+
+        if first_row_has_zero:
+            for col in range(n):
+                matrix[0][col] = 0
+        if first_col_has_zero:
+            for row in range(m):
+                matrix[row][0] = 0
+# @lc code=end

--- a/problems/medium/python3/73/set-matrix-zeroes.step3.py
+++ b/problems/medium/python3/73/set-matrix-zeroes.step3.py
@@ -1,0 +1,28 @@
+#
+# @lc app=leetcode id=73 lang=python3
+#
+# [73] Set Matrix Zeroes
+#
+
+# @lc code=start
+class Solution:
+    def setZeroes(self, matrix: List[List[int]]) -> None:
+        """
+        Do not return anything, modify matrix in-place instead.
+        """
+        m = len(matrix)
+        n = len(matrix[0])
+        row_has_zero = [False] * m
+        col_has_zero = [False] * n
+
+        for row in range(m):
+            for col in range(n):
+                if matrix[row][col] == 0:
+                    row_has_zero[row] = True
+                    col_has_zero[col] = True
+
+        for row in range(m):
+            for col in range(n):
+                if row_has_zero[row] or col_has_zero[col]:
+                    matrix[row][col] = 0
+# @lc code=end


### PR DESCRIPTION
### Problem

- https://leetcode.com/problems/set-matrix-zeroes/description/

### Description

- Step1
    - 14分で Pass
    - 時間計算量：`O(MN)`、空間計算量：~~`O(1)`~~ `O(max(M, N))` ※ リスト内包表記を使っているので一定でない
    - 方針（Note に書いてあるとおり過去に解いたことがあるため、空間計算量を `O(1)` で解く方針をぼんやり覚えていた）
        - 1行目と1列目に 0 が含まれるかどうかを確認し、`first_xxx_is_zero` フラグとして持つ
        - 1行目と1列目を各行や列を 0 とすべきかどうかのフラグのように扱う
            - ex. i 行目 (1 <= i < m) が 0 の場合には `matrix[i][0] = 0`、 j 列目 (1 <= j < n) が 0 の場合には `matrix[0][j] = 0`
        - 1行目と1列目の値を元に該当行や列を 0 に更新
        - `first_xxx_is_zero` のフラグに基づいて、1行目1列目を 0 に更新
    - 考えたこと
        - `first_xxx_is_zero` ははじめ for ループを使っていたが、`any()` を使う方がスッキリするので途中で採用
        - 上の変数名は文章になってしまっているのでいまいちかと思いつつもいいものが思いつかずそのまま採用
        - 行の更新は `matrix[row] = [0 for _ in range(n)]` のように一気に書き換えられるが、列の更新はスマートにできず for ループで愚直に更新
            - 転置して列を行のように扱うことも検討したが、返って煩雑になるかと思い採用せず
- Step2
    - 命名の修正
        - `first_xxx_is_zero` よりは `first_xxx_has_zero` の方が適切だったので修正
    - 処理の修正
        - 行や列の更新部分は Step1 では行ごと列ごとにしていたが、シンプルになるかと思い二重ループにしてまとめた
            - 元々二重ループを使っている部分があるので、ここを二重ループにしても時間計算量は変わらない（処理時間は少し長くなるかも）
        - 1行目と1列目の更新部分は対称性がわかりやすいよう同じ処理に変更
            - Step1 では行の更新は `matrix[row] = [0 for _ in range(n)]` でやっていたが、行と列で更新方法が非対称なのが気になった
    - その他考えたこと
        - Solutions の中には `first_xxx_has_zero` のようなフラグを1つだけ持たせている解答もあったが、個人的に行と列で対称に処理されたほうがわかりやすいと思ったためフラグは2つ持たせたままとした
        - `first_row_has_zero = any([matrix[0][col] == 0 for col in range(n)])` のように一時的でもリスト内包表記を使うと空間計算量は変わる？フラグ単体で `O(1)` と思ったが、リスト内包表記を使っているので `O(N)` となる？
            - → リスト内包表記を使っているので `O(N)`、Generator を使っていた場合は `O(1)` となる
- Step3
    - ~~Step1 で15分以内に解けたので Skip~~
    - 空間計算量 `O(m + n)` の読みやすいシンプルな解法でも書いてみました

### Note

- 同じ問題を1年2ヶ月前に解いた経験あり
