### PR TITLE
79. Word Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ LeetCode の問題を以下手順で解く
 | 54  | [Spiral Matrix](https://leetcode.com/problems/spiral-matrix/description/)                                                                   | Python3  | Medium     |
 | 55  | [Jump Game](https://leetcode.com/problems/jump-game/description/)                                                                           | Python3  | Medium     |
 | 73  | [Set Matrix Zeroes](https://leetcode.com/problems/set-matrix-zeroes/description/)                                                           | Python3  | Medium     |
+| 79  | [Word Search](https://leetcode.com/problems/word-search/description/)                                                                       | Python3  | Medium     |
 | 143 | [Reorder List](https://leetcode.com/problems/reorder-list/description/)                                                                     | Python3  | Medium     |
 | 153 | [Find Minimum in Rotated Sorted Array](https://leetcode.com/problems/find-minimum-in-rotated-sorted-array/description/)                     | Python3  | Medium     |
 | 207 | [Course Schedule](https://leetcode.com/problems/ourse-schedule/description/)                                                                | Python3  | Medium     |

--- a/problems/medium/python3/79/word-search.step1.py
+++ b/problems/medium/python3/79/word-search.step1.py
@@ -1,0 +1,41 @@
+#
+# @lc app=leetcode id=79 lang=python3
+#
+# [79] Word Search
+#
+
+# @lc code=start
+class Solution:
+    def exist(self, board: List[List[str]], word: str) -> bool:
+        m = len(board)
+        n = len(board[0])
+        if (m == 1) and (n == 1):
+            return board[0][0] == word
+
+        word_exists = False
+
+        def isInside(row: int, col: int) -> bool:
+            return (0 <= row < m) and (0 <= col < n)
+
+        def search(row: int, col: int, index: int) -> bool:
+            if index == len(word):
+                nonlocal word_exists
+                word_exists = True
+                return
+
+            if board[row][col] != word[index]:
+                return
+
+            tmp = board[row][col]
+            board[row][col] = "#"
+            for dr, dc in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                if not isInside(row + dr, col + dc):
+                    continue
+                search(row + dr, col + dc, index + 1)
+            board[row][col] = tmp
+
+        for row in range(m):
+            for col in range(n):
+                search(row, col, 0)
+        return word_exists
+# @lc code=end

--- a/problems/medium/python3/79/word-search.step2.py
+++ b/problems/medium/python3/79/word-search.step2.py
@@ -1,0 +1,37 @@
+#
+# @lc app=leetcode id=79 lang=python3
+#
+# [79] Word Search
+#
+
+# @lc code=start
+class Solution:
+    def exist(self, board: List[List[str]], word: str) -> bool:
+        m = len(board)
+        n = len(board[0])
+
+        def is_inside(row: int, col: int) -> bool:
+            return (0 <= row < m) and (0 <= col < n)
+
+        def search(row: int, col: int, index: int) -> bool:
+            if not is_inside(row, col) or board[row][col] != word[index]:
+                return False
+            if index == len(word) - 1:
+                return True
+
+            tmp = board[row][col]
+            board[row][col] = "#"
+
+            word_exists = False
+            for dr, dc in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                word_exists |= search(row + dr, col + dc, index + 1)
+
+            board[row][col] = tmp
+            return word_exists
+
+        for row in range(m):
+            for col in range(n):
+                if search(row, col, 0):
+                    return True
+        return False
+# @lc code=end

--- a/problems/medium/python3/79/word-search.step3.py
+++ b/problems/medium/python3/79/word-search.step3.py
@@ -1,0 +1,39 @@
+#
+# @lc app=leetcode id=79 lang=python3
+#
+# [79] Word Search
+#
+
+# @lc code=start
+class Solution:
+    def exist(self, board: List[List[str]], word: str) -> bool:
+        m = len(board)
+        n = len(board[0])
+
+        def is_inside(row: int, col: int) -> bool:
+            return (0 <= row < m) and (0 <= col < n)
+
+        def search(row: int, col: int, index: int) -> bool:
+            if board[row][col] != word[index]:
+                return False
+            if index == len(word) - 1:
+                return True
+
+            tmp = board[row][col]
+            board[row][col] = "#"
+
+            word_exists = False
+            for dr, dc in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                if not is_inside(row + dr, col + dc):
+                    continue
+                word_exists |= search(row + dr, col + dc, index + 1)
+
+            board[row][col] = tmp
+            return word_exists
+
+        for row in range(m):
+            for col in range(n):
+                if search(row, col, 0):
+                    return True
+        return False
+# @lc code=end

--- a/problems/medium/python3/79/word-search.step4.py
+++ b/problems/medium/python3/79/word-search.step4.py
@@ -1,0 +1,41 @@
+#
+# @lc app=leetcode id=79 lang=python3
+#
+# [79] Word Search
+#
+
+# @lc code=start
+class Solution:
+    def exist(self, board: List[List[str]], word: str) -> bool:
+        m = len(board)
+        n = len(board[0])
+
+        def is_inside(row: int, col: int) -> bool:
+            return (0 <= row < m) and (0 <= col < n)
+
+        def search(start_row: int, start_col: int) -> bool:
+            visited = set()
+            candidates = [(start_row, start_col, 0, visited)]
+            while candidates:
+                row, col, index, visited = candidates.pop()
+                if not is_inside(row, col):
+                    continue
+                if board[row][col] != word[index]:
+                    continue
+                if (row, col) in visited:
+                    continue
+                if index == len(word) - 1:
+                    return True
+
+                copied_visited = deepcopy(visited)
+                copied_visited.add((row, col))
+                for dr, dc in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                    candidates.append((row + dr, col + dc, index + 1, copied_visited))
+            return False
+
+        for row in range(m):
+            for col in range(n):
+                if search(row, col):
+                    return True
+        return False
+# @lc code=end

--- a/problems/medium/python3/79/word-search.step5.py
+++ b/problems/medium/python3/79/word-search.step5.py
@@ -1,0 +1,44 @@
+#
+# @lc app=leetcode id=79 lang=python3
+#
+# [79] Word Search
+#
+
+# @lc code=start
+class Solution:
+    def exist(self, board: List[List[str]], word: str) -> bool:
+        m = len(board)
+        n = len(board[0])
+        directions = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+        found = False
+
+        def is_inside(row: int, col: int) -> bool:
+            return 0 <= row < m and 0 <= col < n
+
+        def search(start_row: int, start_col: int):
+            nonlocal found
+            candidates = [(start_row, start_col, 0, 0)]
+            while candidates:
+                row, col, word_index, direction_index = candidates.pop()
+                if direction_index == len(directions):
+                    board[row][col] = word[word_index]
+                    continue
+
+                if direction_index == 0:
+                    if board[row][col] != word[word_index]:
+                        continue
+                    if word_index == len(word) - 1:
+                        found = True
+                        return
+                    board[row][col] = "#"
+
+                dr, dc = directions[direction_index]
+                candidates.append((row, col, word_index, direction_index + 1))
+                if is_inside(row + dr, col + dc):
+                    candidates.append((row + dr, col + dc, word_index + 1, 0))
+
+        for row in range(m):
+            for col in range(n):
+                search(row, col)
+        return found
+# @lc code=end


### PR DESCRIPTION
### Problem

- https://leetcode.com/problems/word-search/description/

### Description

- Step1
    - 25分で Pass
    - 時間計算量：`O(MN * 3^W)`、空間計算量：`O(W)`
        - 時間計算量はまったく自信がないが、m x n 個の始点で各マスから（元々いたマスを除いて）3方向への分岐が最大で `len(word)` 分繰り返されると考えた（実際は通過済みのマスも取り除かれるからもっと少なそうではある）
            - 似たようなコードで `len(word)` 分行ききるか、通過済みのセルにぶつかるまで探索する回数をカウントして検証してみたが、`m = n = 6` かつ `len(word) = 6` のときで540通りくらいだったので、時間計算量の見積もりは全然違いそう…（検証コードが間違っている説もあるが）
        - 空間計算量は最大で再帰の深さが `len(word)` となるはず
    - 方針
        - m x n 個の全セルを始点にして DFS で探索
        - 自分がすでに通った部分は通れないので適当な文字に置き換える前処理と元の文字に戻す後処理が必要なので再帰で実装
    - 引っ掛かりポイント
        - はじめは stack を使い実装しようと考えたが、通過済みのセルをうまく扱えなさそうだったので上記のとおり再帰を使った実装に方針変更
        - 再帰関数の `search()` で `bool` を返り値にしてできないかも検討したが、これも同様にうまく扱えなさそうだったのであらかじめ宣言していた `word_exists` に代入する実装にした
        - `nonlocal` 宣言
            - `nonlocal` を使わずに関数内関数で代入してしまい、常に初期値の False を返していた
        - `m = n = 1` のエッジケース対応
            - 特別扱いせずに解けないか検討したがいいアイデアが思いつかず、結局このケースだけはじめに確認
- Step2
    - 変数名の修正
        - なぜか `isInside()` と camelCase にしていたので、snake_case の `is_inside()` に変更
    - 処理の修正（[この解法](https://leetcode.com/problems/word-search/solutions/4965284/easily-explained-with-visualization-c-java-python/) を参考）
        - `search()` で `bool` を返り値にするよう修正
            - 返り値の `or` をとることで1パターンでも発見されれば `True` とできるので Step1 のように別で変数を持つ必要がなくなる
            - 参考にした解法では 4つのケースで `or` をとっていたが、個人的にはわかりにくかったので for ループと `|=` を採用
        - 元々 `index == len(word)` で `True` となるような判定にしていたが、`board[row][col] == word[index]` の判定の後に `index == len(word) - 1` という条件を置くことで `m = n = 1` のエッジケース対応を不要とした
- Step3
    - Step2 では `search()` のはじめに「`row`, `col` が `board` の範囲内かどうか」を判定していたが、そもそも範囲外の場合は `search()` を呼び出さないように修正
    - `m`, `n` をわざわざ持つ必要がないかとも思ったが、解法の中で2回出てくるのと個人的に `len(board)` よりもわかりやすいと感じたのでそのまま使用
    - `is_inside()` も1回しか使われないため定義不要かと考えたが、個人的には関数名から意図が汲み取りやすいと感じたのでそのまま使用
    - `tmp` という変数名もどうかと考えたが、まさしく一時保管という意味なのでむしろ `tmp` が適切と思ったためそのまま使用

### Note

- 同じ問題を1年3ヶ月前に解いた経験あり
