### PR TITLE
19. Remove Nth Node From End of List

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ LeetCode の問題を以下手順で解く
 | 3   | [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters/description/) | Python3  | Medium     |
 | 5   | [Longest Palindromic Substring](https://leetcode.com/problems/longest-palindromic-substring/description/)                                   | Python3  | Medium     |
 | 11  | [Container With Most Water](https://leetcode.com/problems/container-with-most-water/description/)                                           | Python3  | Medium     |
+| 19  | [Remove Nth Node From End of List](https://leetcode.com/problems/remove-nth-node-from-end-of-list/description/)                             | Python3  | Medium     |
 | 54  | [Spiral Matrix](https://leetcode.com/problems/spiral-matrix/description/)                                                                   | Python3  | Medium     |
 | 55  | [Jump Game](https://leetcode.com/problems/jump-game/description/)                                                                           | Python3  | Medium     |
 | 73  | [Set Matrix Zeroes](https://leetcode.com/problems/set-matrix-zeroes/description/)                                                           | Python3  | Medium     |

--- a/problems/medium/python3/19/remove-nth-node-from-end-of-list.step1.py
+++ b/problems/medium/python3/19/remove-nth-node-from-end-of-list.step1.py
@@ -1,0 +1,25 @@
+#
+# @lc app=leetcode id=19 lang=python3
+#
+# [19] Remove Nth Node From End of List
+#
+
+# @lc code=start
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def removeNthFromEnd(self, head: Optional[ListNode], n: int) -> Optional[ListNode]:
+        dummy_head = ListNode(0, head)
+        fast = dummy_head
+        for _ in range(n):
+            fast = fast.next
+        slow = dummy_head
+        while fast.next:
+            fast = fast.next
+            slow = slow.next
+        slow.next = slow.next.next
+        return dummy_head.next
+# @lc code=end

--- a/problems/medium/python3/19/remove-nth-node-from-end-of-list.step2.py
+++ b/problems/medium/python3/19/remove-nth-node-from-end-of-list.step2.py
@@ -1,0 +1,27 @@
+#
+# @lc app=leetcode id=19 lang=python3
+#
+# [19] Remove Nth Node From End of List
+#
+
+# @lc code=start
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def removeNthFromEnd(self, head: Optional[ListNode], n: int) -> Optional[ListNode]:
+        dummy_head = ListNode(0, head)
+        first = dummy_head
+        for _ in range(n):
+            if first is None:
+                raise RuntimeError(f"{n} is greater than the length of the ListNode.")
+            first = first.next
+        second = dummy_head
+        while first and first.next:
+            first = first.next
+            second = second.next
+        second.next = second.next.next
+        return dummy_head.next
+# @lc code=end

--- a/problems/medium/python3/19/remove-nth-node-from-end-of-list.step3.py
+++ b/problems/medium/python3/19/remove-nth-node-from-end-of-list.step3.py
@@ -1,0 +1,27 @@
+#
+# @lc app=leetcode id=19 lang=python3
+#
+# [19] Remove Nth Node From End of List
+#
+
+# @lc code=start
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def removeNthFromEnd(self, head: Optional[ListNode], n: int) -> Optional[ListNode]:
+        dummy_head = ListNode(0, head)
+        fast = dummy_head
+        for _ in range(n):
+            if fast.next is None:
+                raise RuntimeError(f"{n} is greater than the length of the ListNode.")
+            fast = fast.next
+        slow = dummy_head
+        while fast.next is not None:
+            fast = fast.next
+            slow = slow.next
+        slow.next = slow.next.next
+        return dummy_head.next
+# @lc code=end

--- a/problems/medium/python3/19/remove-nth-node-from-end-of-list.step3.py
+++ b/problems/medium/python3/19/remove-nth-node-from-end-of-list.step3.py
@@ -12,13 +12,13 @@
 #         self.next = next
 class Solution:
     def removeNthFromEnd(self, head: Optional[ListNode], n: int) -> Optional[ListNode]:
-        dummy_head = ListNode(0, head)
+        dummy_head = ListNode(next=head)
         fast = dummy_head
+        slow = dummy_head
         for _ in range(n):
             if fast.next is None:
                 raise RuntimeError(f"{n} is greater than the length of the ListNode.")
             fast = fast.next
-        slow = dummy_head
         while fast.next is not None:
             fast = fast.next
             slow = slow.next


### PR DESCRIPTION
### Problem

- https://leetcode.com/problems/remove-nth-node-from-end-of-list/description/

### Description

- Step1
    - 7分で Pass
    - 時間計算量：`O(N)`、空間計算量：`O(1)`
    - 方針
        - 後ろから n 番目を削除するので、はじめに n 個分進めたポインタと先頭においたポインタの2つを動かしていき、先のポインタが到達した際に後のポインタの次をスキップする
        - 先頭に dummy node を置くことで、答えが None になる場合の細かい分岐をなくした（このケースの対応に少し時間がかかった）
- Step2
    - 変数名を `fast`, `slow` としていたが、速度は変わらないので `first`, `second` に変更
        - Floyd’s Cycle Finding Algorithm などでは、速度が違うので `fast`, `slow` がわかりやすそう
    - 制約条件として n が ListNode の長さを超えることはないが念のためケア
    - while ループの条件も制約条件内では `fast.next` だけでいいが、念のため `fast and fast.next` でケア
- Step3
    - ~~Skip~~
    - [Mike0121](https://github.com/Mike0121) さんと [fhiyo](https://github.com/fhiyo) さんにもらったコメントに対する修正を追加

### Note

- 同じ問題を6ヶ月前に解いた経験あり
